### PR TITLE
use pmap to normalize reward model

### DIFF
--- a/lm_human_preference_details/train_reward_accelerate.py
+++ b/lm_human_preference_details/train_reward_accelerate.py
@@ -86,7 +86,9 @@ class Args:
     """the learning rate"""
     eps: float = 1e-5
     """the epsilon for AdamW"""
-    rollout_batch_size: int = 512
+    local_rollout_batch_size: int = 64
+    """per rank rollout batch size"""
+    rollout_batch_size: tyro.conf.Suppress[int] = None
     """rollout batch size"""
     world_size: tyro.conf.Suppress[int] = None
     """the number of processes to use"""
@@ -395,12 +397,12 @@ def normalize(
     generation_config,
 ):
     with torch.no_grad():
+
         # reset reward scales
         accelerator.unwrap_model(reward_model).reward_gain.data.fill_(1.0)
         accelerator.unwrap_model(reward_model).reward_bias.data.fill_(0.0)
-
-        # sample queries and responses
-        n_batches = ceil_div(args.local_normalize_samples, args.rollout_batch_size)
+        # number of minibatches for computing the normalization statistics
+        n_batches = ceil_div(args.local_normalize_samples, args.local_rollout_batch_size)
         sample_queries_responses = []
         for _ in range(n_batches):
             data = next(iter_dataloader)
@@ -415,7 +417,6 @@ def normalize(
             rewards.append(get_reward(reward_model, query_responses, args)[1])
         rewards = torch.cat(rewards)
         rewards = accelerator.gather(rewards)
-        # shape: [args.local_normalize_samples, 1]
         mean, std = rewards.mean(), rewards.std()
         print(f"mean: {mean}, std: {std}")
 
@@ -428,7 +429,7 @@ def normalize(
         accelerator.unwrap_model(reward_model).reward_bias.data = bias
 
         # validate normalization
-        n_batches = ceil_div(args.local_normalize_samples, args.rollout_batch_size)
+        n_batches = ceil_div(args.local_normalize_samples, args.local_rollout_batch_size)
         sample_queries_responses = []
         for _ in range(n_batches):
             data = next(iter_dataloader)
@@ -454,6 +455,7 @@ def train(args: Args):
     )
     args.world_size = accelerator.num_processes
     args.batch_size = int(args.local_batch_size * args.world_size)
+
     args.local_micro_batch_size = exact_div(args.local_batch_size, args.gradient_accumulation_steps)
 
     console = Console(force_terminal=True)
@@ -514,7 +516,7 @@ def train(args: Args):
         start_text=args.task.start_text,
         end_text=args.task.end_text,
     )
-    normalization_dataloader = DataLoader(normalization_dataset, batch_size=args.rollout_batch_size)
+    normalization_dataloader = DataLoader(normalization_dataset, batch_size=args.local_rollout_batch_size)
     reward_model, optimizer, normalization_dataloader = accelerator.prepare(reward_model, optimizer, normalization_dataloader)
     iter_normalization_dataloader = iter(normalization_dataloader)
 

--- a/lm_human_preference_details/train_reward_accelerate.py
+++ b/lm_human_preference_details/train_reward_accelerate.py
@@ -86,7 +86,7 @@ class Args:
     """the learning rate"""
     eps: float = 1e-5
     """the epsilon for AdamW"""
-    local_rollout_batch_size: int = 64
+    local_rollout_batch_size: int = 512
     """per rank rollout batch size"""
     rollout_batch_size: tyro.conf.Suppress[int] = None
     """rollout batch size"""
@@ -397,7 +397,6 @@ def normalize(
     generation_config,
 ):
     with torch.no_grad():
-
         # reset reward scales
         accelerator.unwrap_model(reward_model).reward_gain.data.fill_(1.0)
         accelerator.unwrap_model(reward_model).reward_bias.data.fill_(0.0)
@@ -455,6 +454,7 @@ def train(args: Args):
     )
     args.world_size = accelerator.num_processes
     args.batch_size = int(args.local_batch_size * args.world_size)
+    args.rollout_batch_size = int(args.local_rollout_batch_size * args.world_size)
 
     args.local_micro_batch_size = exact_div(args.local_batch_size, args.gradient_accumulation_steps)
 

--- a/lm_human_preference_details/train_reward_jax.py
+++ b/lm_human_preference_details/train_reward_jax.py
@@ -89,7 +89,7 @@ class Args:
     """the learning rate"""
     eps: float = 1e-5
     """the epsilon for AdamW"""
-    local_rollout_batch_size: int = 64
+    local_rollout_batch_size: int = 512
     """per rank rollout batch size"""
     rollout_batch_size: tyro.conf.Suppress[int] = None
     """rollout batch size"""
@@ -649,7 +649,7 @@ def train(args: Args):
         start_text=args.task.start_text,
         end_text=args.task.end_text,
     )
-    normalization_dataloader = DataLoader(normalization_dataset, batch_size=args.rollout_batch_size)
+    normalization_dataloader = DataLoader(normalization_dataset, batch_size=args.rollout_batch_size * len(local_devices))
     iter_normalization_dataloader = iter(normalization_dataloader)
 
     generation_config = GenerationConfig(

--- a/lm_human_preference_details/train_reward_jax.py
+++ b/lm_human_preference_details/train_reward_jax.py
@@ -95,8 +95,10 @@ class Args:
     """the number of processes to use"""
     batch_size: tyro.conf.Suppress[int] = None
     """the batch size across all ranks"""
-    normalize_samples: int = 256
+    local_normalize_samples: int = 256
     """Samples used to estimate reward mean and std"""
+    normalize_samples: tyro.conf.Suppress[int] = None
+    """Samples used to estimate reward mean and std across all ranks"""
     debug_normalize: int = 0
     """Samples used to check that normalization worked"""
     normalize_before: bool = True
@@ -580,6 +582,8 @@ def train(args: Args):
     args.global_learner_decices = [str(item) for item in global_learner_decices]
     args.learner_devices = [str(item) for item in learner_devices]
     args.batch_size = int(args.local_batch_size * len(local_devices) * args.world_size)
+    args.normalize_samples =  int(args.local_normalize_samples * len(local_devices) * args.world_size)
+
     args.local_rank = jax.process_index()
 
     run_name = f"{args.exp_name}__{args.seed}__{int(time.time())}"

--- a/lm_human_preference_details/train_reward_jax.py
+++ b/lm_human_preference_details/train_reward_jax.py
@@ -649,7 +649,7 @@ def train(args: Args):
         start_text=args.task.start_text,
         end_text=args.task.end_text,
     )
-    normalization_dataloader = DataLoader(normalization_dataset, batch_size=args.rollout_batch_size * len(local_devices))
+    normalization_dataloader = DataLoader(normalization_dataset, batch_size=args.local_rollout_batch_size * len(local_devices))
     iter_normalization_dataloader = iter(normalization_dataloader)
 
     generation_config = GenerationConfig(

--- a/lm_human_preference_details/train_reward_jax.py
+++ b/lm_human_preference_details/train_reward_jax.py
@@ -95,10 +95,8 @@ class Args:
     """the number of processes to use"""
     batch_size: tyro.conf.Suppress[int] = None
     """the batch size across all ranks"""
-    local_normalize_samples: int = 256
+    normalize_samples: int = 256
     """Samples used to estimate reward mean and std"""
-    normalize_samples: tyro.conf.Suppress[int] = None
-    """Samples used to estimate reward mean and std across all ranks"""
     debug_normalize: int = 0
     """Samples used to check that normalization worked"""
     normalize_before: bool = True
@@ -107,7 +105,7 @@ class Args:
     """Whether, after training, to normalize the rewards on the ref policy to mean 0, var 1 (so the KL coefficient always has the same meaning)."""
     print_sample_output_freq: int = 10
     """How often to print sample output"""
-    save_path: str = "models/reward.pt"
+    save_path: str = "models/"
     """Where to save the model"""
     use_tensorflow_adam: bool = True
     """Whether to use tensorflow-style Adam optimizer instead of PyTorch's"""
@@ -117,9 +115,9 @@ class Args:
     """the rank of this process"""
     learner_device_ids: List[int] = field(default_factory=lambda: [0])
     "the device ids that script will use"
-    learner_devices: tyro.conf.Suppress[int] = None # real type is `List[str]`
+    learner_devices: tyro.conf.Suppress[int] = None  # real type is `List[str]`
     """the devices that script will use"""
-    global_learner_decices: tyro.conf.Suppress[int] = None # real type is `List[str]`
+    global_learner_decices: tyro.conf.Suppress[int] = None  # real type is `List[str]`
     """the total devices (across all nodes and machines) that script will use"""
     task: TaskHParams = field(default_factory=TaskHParams)
     labels: LabelHParams = field(default_factory=LabelHParams)
@@ -278,8 +276,7 @@ def exact_div(a, b):
     return q
 
 
-# TODO: pmap `generate` to accelerate reward model normalization?
-def generate(lm_backbone, queries, args, generation_config):
+def generate(queries, lm_backbone, args, generation_config):
     """generate in a way that does not affect padding tokens"""
     context_length = queries.shape[1]
     attention_mask = queries != args.pad_token_id
@@ -380,8 +377,8 @@ def set_reward_state_head_params(reward_state: TrainState, gain: float = 1.0, bi
     """
     flat_head_params = traverse_util.flatten_dict(reward_state.params.head_params, sep="/")
 
-    flat_head_params["params/reward_gain"] = jnp.array(gain, dtype=jnp.float32)
-    flat_head_params["params/reward_bias"] = jnp.array(bias, dtype=jnp.float32)
+    flat_head_params["params/reward_gain"] = flat_head_params["params/reward_gain"].at[:].set(gain)
+    flat_head_params["params/reward_bias"] = flat_head_params["params/reward_bias"].at[:].set(bias)
 
     unflat_head_params = freeze(traverse_util.unflatten_dict(flat_head_params, sep="/"))
 
@@ -402,10 +399,20 @@ def normalize(
     generation_config,
 ):
     # number of minibatches for computing the normalization statistics
-    n_batches = ceil_div(args.local_normalize_samples, args.rollout_batch_size)
+    n_batches = ceil_div(args.normalize_samples, args.rollout_batch_size)
 
     # reset reward scales
     reward_state = set_reward_state_head_params(reward_state, gain=1.0, bias=0.0)
+
+    p_generate = jax.pmap(
+        functools.partial(
+            generate,
+            lm_backbone=lm_backbone,
+            args=args,
+            generation_config=generation_config,
+        ),
+    )
+    p_apply_fn = jax.pmap(reward_state.apply_fn)
 
     def get_normalization_stats(reward_state):
         """compute mean and std of rewards"""
@@ -415,22 +422,20 @@ def normalize(
             data = next(iter_dataloader)
             queries = data["input_ids"]
             queries = right_padding_to_left_padding(data["input_ids"], args.pad_token_id)
-            query_responses = generate(lm_backbone, queries, args, generation_config)
+            queries = common_utils.shard(queries)
+            query_responses = p_generate(queries)
             sample_queries_responses.append(query_responses)
 
         rewards = []
         for query_responses in sample_queries_responses:
             rewards.append(
-                reward_state.apply_fn(
+                p_apply_fn(
                     reward_state.params,
                     query_responses,
                 )
             )
-        # Here, len(rewards) = n_batches
-        # each rewards[i] is a (args.rollout_batch_size, 1) array.
 
         rewards = np.concatenate(rewards)
-        # shape: [args.local_normalize_samples, 1]
         mean, std = rewards.mean(), rewards.std()
         print(f"mean: {mean}, std: {std}")
         return mean, std
@@ -649,6 +654,8 @@ def train(args: Args):
         pad_token_id=args.pad_token_id,
     )
 
+    reward_state = jax_utils.replicate(reward_state)
+
     if args.normalize_before:
         print("===Normalize reward model *before* training===")
 
@@ -671,8 +678,6 @@ def train(args: Args):
             + f"Gain: {reward_state.params.head_params['params']['reward_gain']}"
             + f" Bias: {reward_state.params.head_params['params']['reward_bias']}"
         )
-
-    reward_state = jax_utils.replicate(reward_state)
 
     # `labeled_dataset` has keys
     # `['sample0', 'query', 'best', 'sample3', 'sample1', 'sample2']`
@@ -735,8 +740,6 @@ def train(args: Args):
 
             print(f"gloabl_step: {global_step} | " + f"test/accuracy {val_metrics['accuracy']}")
 
-    reward_state = jax_utils.unreplicate(reward_state)
-
     if args.normalize_after:
         print("===Normalize reward model *after* training===")
         print(
@@ -757,6 +760,8 @@ def train(args: Args):
             + f"Gain: {reward_state.params.head_params['params']['reward_gain']}"
             + f" Bias: {reward_state.params.head_params['params']['reward_bias']}"
         )
+
+    reward_state = jax_utils.unreplicate(reward_state)
 
     # save model
     if args.save_path and args.local_rank == 0:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -3,7 +3,7 @@ import subprocess
 
 def test_torch():
     subprocess.run(
-        "python lm_human_preference_details/train_both_accelerate.py --reward.task.query_dataset dummy --policy.task.query_dataset dummy --reward.labels.num_train 4 --reward.local_normalize_samples 4 --reward.rollout_batch_size 4 --policy.ppo.total_episodes 8 --policy.ppo.local_batch_size 4 --policy.ppo.no_whiten_rewards", 
+        "python lm_human_preference_details/train_both_accelerate.py --reward.task.query_dataset dummy --policy.task.query_dataset dummy --reward.labels.num_train 4 --reward.normalize_samples 4 --reward.rollout_batch_size 4 --policy.ppo.total_episodes 8 --policy.ppo.local_batch_size 4 --policy.ppo.no_whiten_rewards", 
         shell=True,
         check=True,
     )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -3,7 +3,7 @@ import subprocess
 
 def test_torch():
     subprocess.run(
-        "python lm_human_preference_details/train_both_accelerate.py --reward.task.query_dataset dummy --policy.task.query_dataset dummy --reward.labels.num_train 4 --reward.local_normalize_samples 4 --reward.rollout_batch_size 4 --policy.ppo.total_episodes 8 --policy.ppo.local_batch_size 4 --policy.ppo.no_whiten_rewards", 
+        "python lm_human_preference_details/train_both_accelerate.py --reward.task.query_dataset dummy --policy.task.query_dataset dummy --reward.labels.num_train 4 --reward.local_normalize_samples 4 --reward.local_rollout_batch_size 4 --policy.ppo.total_episodes 8 --policy.ppo.local_batch_size 4 --policy.ppo.no_whiten_rewards",
         shell=True,
         check=True,
     )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -3,7 +3,7 @@ import subprocess
 
 def test_torch():
     subprocess.run(
-        "python lm_human_preference_details/train_both_accelerate.py --reward.task.query_dataset dummy --policy.task.query_dataset dummy --reward.labels.num_train 4 --reward.normalize_samples 4 --reward.rollout_batch_size 4 --policy.ppo.total_episodes 8 --policy.ppo.local_batch_size 4 --policy.ppo.no_whiten_rewards", 
+        "python lm_human_preference_details/train_both_accelerate.py --reward.task.query_dataset dummy --policy.task.query_dataset dummy --reward.labels.num_train 4 --reward.local_normalize_samples 4 --reward.rollout_batch_size 4 --policy.ppo.total_episodes 8 --policy.ppo.local_batch_size 4 --policy.ppo.no_whiten_rewards", 
         shell=True,
         check=True,
     )


### PR DESCRIPTION
Hey!

As discussed in our [previous PR](https://github.com/vwxyzjn/lm-human-preference-details/pull/13), we can use `pmap` to accelerate the reward model normalization step. This PR does that. 

Fig below shows that the run time comparison between the pmapped version (cyan) and the previous version (grey). Both versions use `normalize_before` and `normalize_after`. The normalization step of the pmapped version is faster.

![Screenshot from 2023-09-02 11-41-21](https://github.com/vwxyzjn/lm-human-preference-details/assets/10226549/74a9f554-b186-4164-bcb7-9849157a9167)

Test results are almost identical:
![Screenshot from 2023-09-02 11-43-54](https://github.com/vwxyzjn/lm-human-preference-details/assets/10226549/961d2c11-4c75-4cd7-85a3-ddbfd4ae739e)

Additionally, I noted that in our previous pytorch and jax versions, we have an argument `args.normalize_samples` not used. We instead used `args.local_normalize_samples` to effectively mean `args.normalize_samples`. In this PR, I replaced all `args.local_normalize_samples` by `args.normalize_samples`. But feel free to suggest edits if `args.local_normalize_samples` is still needed.
