### PR TITLE
Pass `eps` to adam optimizer and correct minor typos

### DIFF
--- a/lm_human_preference_details/train_policy_jax.py
+++ b/lm_human_preference_details/train_policy_jax.py
@@ -633,6 +633,7 @@ def train(args: Args):
     optimizer = optax.MultiSteps(
         optax.inject_hyperparams(adam)(
             learning_rate=functools.partial(linear_schedule, args=args),
+            eps=args.ppo.eps,
         ),
         every_k_schedule=args.ppo.gradient_accumulation_steps,
     )

--- a/lm_human_preference_details/train_reward_accelerate.py
+++ b/lm_human_preference_details/train_reward_accelerate.py
@@ -86,7 +86,7 @@ class Args:
     lr: float = 0.00005
     """the learning rate"""
     eps: float = 1e-5
-    """the epsilon for AdamW"""
+    """the epsilon for Adam"""
     local_rollout_batch_size: int = 512
     """per rank rollout batch size"""
     rollout_batch_size: tyro.conf.Suppress[int] = None

--- a/lm_human_preference_details/train_reward_jax.py
+++ b/lm_human_preference_details/train_reward_jax.py
@@ -88,7 +88,7 @@ class Args:
     lr: float = 0.00005
     """the learning rate"""
     eps: float = 1e-5
-    """the epsilon for AdamW"""
+    """the epsilon for Adam"""
     local_rollout_batch_size: int = 512
     """per rank rollout batch size"""
     rollout_batch_size: tyro.conf.Suppress[int] = None
@@ -358,6 +358,7 @@ def create_initial_reward_state_and_models(init_key, args):
     optimizer = optax.MultiSteps(
         optax.inject_hyperparams(adam)(
             learning_rate=functools.partial(single_epoch_linear_schedule, args=args),
+            eps=args.eps,
         ),
         every_k_schedule=args.gradient_accumulation_steps,
     )


### PR DESCRIPTION
- In the previous jax implementations, I forgot to pass `eps` to optax adam optimzers. This PR fixes it. 
- Fix typos in comments: `AdamW` -> `Adam`